### PR TITLE
fix 'creates' is not a valid attribute for a TaskInclude

### DIFF
--- a/tasks/config-agent.yml
+++ b/tasks/config-agent.yml
@@ -17,7 +17,6 @@
 
 - name: Manage Certificates
   include_tasks: "pki.yml"
-  creates: "/var/lib/icinga2/certs/{{ icinga2_nodename }}.crt"
   tags:
     - install
     - update

--- a/tasks/config-master.yml
+++ b/tasks/config-master.yml
@@ -37,7 +37,6 @@
 
 - name: Manage Certificates
   include_tasks: "pki.yml"
-  creates: "/var/lib/icinga2/certs/{{ icinga2_nodename }}.crt"
   when: inventory_hostname != icinga2_ca_host
   tags:
     - install

--- a/tasks/config-satellite.yml
+++ b/tasks/config-satellite.yml
@@ -35,7 +35,6 @@
 
 - name: Manage Certificates
   include_tasks: "pki.yml"
-  creates: "/var/lib/icinga2/certs/{{ icinga2_nodename }}.crt"
   tags:
     - install
     - update


### PR DESCRIPTION
'creates' is already correctly defined in pki.yml/create cert