### PR TITLE
Add --endpoint to icinga cert command

### DIFF
--- a/tasks/pki.yml
+++ b/tasks/pki.yml
@@ -76,6 +76,7 @@
     --parent_zone {{ icinga2_ZoneName }} \
     --trustedcert /var/lib/icinga2/certs/trustedcert.crt \
     --cn {{ icinga2_nodename }} \
+    --endpoint {{ icinga2_nodename }} \
     --accept-commands \
     --accept-config
   args:


### PR DESCRIPTION
Without having `--endpoint` as a parameter, node setup would
fail and complain that it was missing that parameter, in this version
of Icinga2:

    icinga2 - The Icinga 2 network monitoring daemon (version: r2.10.4-1)